### PR TITLE
feat: Add sourceMap and inlineSources for TypeScript in dev mode

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -321,7 +321,11 @@ const plugins = [
         preferBuiltins: false,
     }),
     typescript({ 
-        tsconfig: './tsconfig.json' 
+        tsconfig: './tsconfig.json',
+        ...(isDev && {
+            sourceMap: true,
+            inlineSources: true
+        })
     }),
     commonjs()
 ]


### PR DESCRIPTION
修复预览模式下 `http://localhost:10101/` 无法debug、查看调用栈的问题

<img width="800" alt="image" src="https://github.com/user-attachments/assets/87914caa-6b89-4e0e-b26e-d4a8c0dc6276">
